### PR TITLE
feat: deflated Sharpe constraint for the experiment approval gate

### DIFF
--- a/packages/contracts/src/experiment-lab.ts
+++ b/packages/contracts/src/experiment-lab.ts
@@ -38,6 +38,7 @@ export const ExperimentConstraintsSchema = z
     minimumTradeCount: z.number().int().min(0).max(1_000_000).optional(),
     walkForwardPositive: z.boolean().optional(),
     runtimeFailureCountEqZero: z.literal(true).optional(),
+    deflatedSharpeGte: z.number().min(0).max(1).optional(),
   })
   .strict();
 
@@ -189,6 +190,7 @@ export const ExperimentConstraintResultSchema = z
       "minimumTradeCount",
       "walkForwardPositive",
       "runtimeFailureCountEqZero",
+      "deflatedSharpeGte",
     ]),
     status: z.enum(["PASS", "FAIL", "UNAVAILABLE"]),
     actual: z.union([z.number().finite(), z.boolean()]).optional(),

--- a/packages/runtime/src/deflated-sharpe.ts
+++ b/packages/runtime/src/deflated-sharpe.ts
@@ -1,0 +1,165 @@
+// Deflated Sharpe Ratio (Bailey & López de Prado, 2014).
+//
+// An experiment compares N participant versions and the approval gate scores
+// each backtest in isolation. Under pure noise the best of N backtests still
+// looks good, so a gate without a deflation bar approves the luckiest draft.
+// The DSR restates a Sharpe as P(true SR > expected max SR of N zero-skill
+// trials), adjusting for sample length and non-normal returns.
+//
+// Pure math, no dependencies. Parity-tested against the numguard reference
+// implementation (tests-ts/deflated-sharpe.test.ts).
+
+const EULER = 0.5772156649015329;
+
+/** Complementary error function (Numerical Recipes 6.2.2, |error| < 1.2e-7). */
+function erfc(x: number): number {
+  const z = Math.abs(x);
+  const t = 1 / (1 + 0.5 * z);
+  const ans =
+    t *
+    Math.exp(
+      -z * z -
+        1.26551223 +
+        t *
+          (1.00002368 +
+            t *
+              (0.37409196 +
+                t *
+                  (0.09678418 +
+                    t *
+                      (-0.18628806 +
+                        t *
+                          (0.27886807 +
+                            t *
+                              (-1.13520398 +
+                                t *
+                                  (1.48851587 +
+                                    t * (-0.82215223 + t * 0.17087277)))))))),
+    );
+  return x >= 0 ? ans : 2 - ans;
+}
+
+function normCdf(x: number): number {
+  return 0.5 * erfc(-x / Math.SQRT2);
+}
+
+/** Inverse standard-normal CDF (Acklam), ~1e-9. */
+function probit(p: number): number {
+  if (!(p > 0 && p < 1)) throw new Error("DEFLATED_SHARPE_PROBIT_DOMAIN");
+  const a = [
+    -3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
+    1.38357751867269e2, -3.066479806614716e1, 2.506628277459239,
+  ];
+  const b = [
+    -5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+    6.680131188771972e1, -1.328068155288572e1,
+  ];
+  const c = [
+    -7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+    -2.549732539343734, 4.374664141464968, 2.938163982698783,
+  ];
+  const d = [
+    7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
+    3.754408661907416,
+  ];
+  const plow = 0.02425;
+  if (p < plow) {
+    const q = Math.sqrt(-2 * Math.log(p));
+    return (
+      (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    );
+  }
+  if (p <= 1 - plow) {
+    const q = p - 0.5;
+    const r = q * q;
+    return (
+      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) *
+        q) /
+      (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    );
+  }
+  const q = Math.sqrt(-2 * Math.log(1 - p));
+  return (
+    -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+    ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+  );
+}
+
+/** Expected Sharpe of the luckiest of `trialCount` zero-skill trials whose SR
+ *  estimates have standard deviation `srStd`. */
+export function expectedMaxSharpe(trialCount: number, srStd: number): number {
+  if (trialCount < 1) throw new Error("DEFLATED_SHARPE_TRIALS_INVALID");
+  if (trialCount === 1) return 0;
+  const z1 = probit(1 - 1 / trialCount);
+  const z2 = probit(1 - 1 / (trialCount * Math.E));
+  return srStd * ((1 - EULER) * z1 + EULER * z2);
+}
+
+export interface DeflatedSharpeResult {
+  /** Observed per-period Sharpe (not annualised). */
+  sharpe: number;
+  /** Expected max Sharpe of `trialCount` zero-skill trials — the bar. */
+  deflationBar: number;
+  /** P(true SR > deflation bar): the deflated Sharpe ratio. */
+  dsr: number;
+  /** P(true SR > 0), no deflation. */
+  psr: number;
+  skew: number;
+  kurt: number;
+  observationCount: number;
+  trialCount: number;
+}
+
+/** DSR of a return series that was selected as one of `trialCount` variants.
+ *  Returns null when the series cannot support the statistic (fewer than
+ *  three returns, or zero variance) — callers should surface UNAVAILABLE. */
+export function deflatedSharpeFromReturns(
+  returns: readonly number[],
+  trialCount: number,
+): DeflatedSharpeResult | null {
+  const n = returns.length;
+  if (n < 3 || trialCount < 1) return null;
+  const mu = returns.reduce((s, r) => s + r, 0) / n;
+  const m2 = returns.reduce((s, r) => s + (r - mu) ** 2, 0) / n;
+  const sd = Math.sqrt(m2);
+  if (sd === 0) return null;
+  const m3 = returns.reduce((s, r) => s + (r - mu) ** 3, 0) / n;
+  const m4 = returns.reduce((s, r) => s + (r - mu) ** 4, 0) / n;
+  const skew = m3 / sd ** 3;
+  const kurt = m4 / sd ** 4; // non-excess: normal = 3
+  const sr = mu / sd;
+  const srStd = 1 / Math.sqrt(n - 1); // SR sampling std under the null
+  const bar = expectedMaxSharpe(trialCount, srStd);
+  const psrDenom = Math.max(1 - skew * sr + ((kurt - 1) / 4) * sr ** 2, 1e-18);
+  const scale = Math.sqrt(n - 1) / Math.sqrt(psrDenom);
+  return {
+    sharpe: sr,
+    deflationBar: bar,
+    dsr: normCdf((sr - bar) * scale),
+    psr: normCdf(sr * scale),
+    skew,
+    kurt,
+    observationCount: n,
+    trialCount,
+  };
+}
+
+/** Convenience: DSR from an equity series (converted to simple returns).
+ *  Non-positive equity points are sentinels for non-trading cycles (see
+ *  projectArtifactEvidence), so transitions into or out of them are skipped
+ *  rather than read as ±100% returns. */
+export function deflatedSharpeFromEquity(
+  equity: readonly number[],
+  trialCount: number,
+): DeflatedSharpeResult | null {
+  const returns: number[] = [];
+  for (let i = 1; i < equity.length; i += 1) {
+    const prev = equity[i - 1];
+    const next = equity[i];
+    if (!Number.isFinite(prev) || !Number.isFinite(next)) continue;
+    if (prev <= 0 || next <= 0) continue;
+    returns.push(next / prev - 1);
+  }
+  return deflatedSharpeFromReturns(returns, trialCount);
+}

--- a/packages/runtime/src/deflated-sharpe.ts
+++ b/packages/runtime/src/deflated-sharpe.ts
@@ -123,7 +123,16 @@ export function deflatedSharpeFromReturns(
   const mu = returns.reduce((s, r) => s + r, 0) / n;
   const m2 = returns.reduce((s, r) => s + (r - mu) ** 2, 0) / n;
   const sd = Math.sqrt(m2);
-  if (sd === 0) return null;
+  // `sd === 0` is exact and a constant series does not reach it: its standard
+  // deviation is floating-point residue rather than a true zero (6.5e-19 for a flat
+  // 0.1% series), so the Sharpe divides out to ~1e15 and this returned a dsr of 1 --
+  // certainty of a real edge, from the one input that carries no information about
+  // one. The residue grows with the number of terms summed, so the floor scales with
+  // n: measured at most 1.96 eps x scale over constant series spanning values
+  // 1e-7..1e3 and lengths 3..10000, while a real series with sigma=1e-12 sits more
+  // than ten orders of magnitude above n eps x scale.
+  const magnitude = returns.reduce((s, r) => Math.max(s, Math.abs(r)), 0);
+  if (!(sd > n * Number.EPSILON * magnitude)) return null;
   const m3 = returns.reduce((s, r) => s + (r - mu) ** 3, 0) / n;
   const m4 = returns.reduce((s, r) => s + (r - mu) ** 4, 0) / n;
   const skew = m3 / sd ** 3;

--- a/packages/runtime/src/experiment-lab.ts
+++ b/packages/runtime/src/experiment-lab.ts
@@ -24,6 +24,7 @@ import {
   type RegisteredGraphHistoricalDatasetRegistry,
   type RegisteredGraphWalkForwardPlanRegistry,
 } from "../../core/src/graph-backtest-evidence.js";
+import { deflatedSharpeFromEquity } from "./deflated-sharpe.js";
 import type { DurableGraphEvidenceJobService } from "./sqlite-graph-evidence-jobs.js";
 import type { PipelineOrchestrationAuthenticator } from "./pipeline-orchestration-auth.js";
 
@@ -658,6 +659,30 @@ function evaluateConstraints(
       expected: 0,
       status: failures === 0 ? "PASS" : "FAIL",
     });
+  }
+  if (configured.deflatedSharpeGte !== undefined) {
+    // Every participant is a trial: the bar rises with the number of
+    // variants this experiment compared, so the gate cannot be beaten by
+    // iterating drafts until one gets lucky.
+    const verdict = deflatedSharpeFromEquity(
+      backtest.equityPoints.map((point) => point.equity),
+      experiment.participants.length,
+    );
+    if (verdict === null) {
+      results.push({
+        key: "deflatedSharpeGte",
+        expected: configured.deflatedSharpeGte,
+        status: "UNAVAILABLE",
+        issueCode: "EXPERIMENT_DEFLATED_SHARPE_SERIES_INSUFFICIENT",
+      });
+    } else {
+      results.push({
+        key: "deflatedSharpeGte",
+        actual: verdict.dsr,
+        expected: configured.deflatedSharpeGte,
+        status: verdict.dsr >= configured.deflatedSharpeGte ? "PASS" : "FAIL",
+      });
+    }
   }
   return results;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -46,6 +46,7 @@ export * from "./sqlite-semantic-pipeline-executions.js";
 export * from "./registered-configurable-semantic-pipeline-execution.js";
 export * from "./historical-semantic-evaluation-http.js";
 export * from "./experiment-lab.js";
+export * from "./deflated-sharpe.js";
 export * from "./multi-paper-runtime.js";
 export * from "./multi-paper-runtime-http.js";
 export * from "./shadow-promotion.js";

--- a/tests-ts/deflated-sharpe.test.ts
+++ b/tests-ts/deflated-sharpe.test.ts
@@ -81,3 +81,31 @@ test("constraints schema accepts and bounds deflatedSharpeGte", () => {
     !ExperimentConstraintsSchema.safeParse({ deflatedSharpeGte: -0.1 }).success,
   );
 });
+
+test("a series with no dispersion is rejected at any value and length", () => {
+  // `sd === 0` is exact and a constant series does not reach it: its standard
+  // deviation is floating-point residue rather than a true zero (6.5e-19 for a flat
+  // 0.1% series), so the Sharpe divided out to ~1e15 and the result came back with a
+  // dsr of 1 -- certainty of a real edge, from the one input that carries no
+  // information about one. The residue depends on both the value and the length, so
+  // the existing three-element case passed while longer ones still leaked.
+  for (const value of [1e-7, 1e-4, 0.001, 0.01, 1, 100]) {
+    for (const n of [3, 10, 250, 5000]) {
+      assert.equal(
+        deflatedSharpeFromReturns(Array(n).fill(value), 4),
+        null,
+        `leaked at value=${value}, n=${n}`,
+      );
+    }
+  }
+
+  // The floor is relative to the scale of the data, so a real but very quiet series
+  // still gets a number.
+  let seed = 1;
+  const quiet = Array.from({ length: 250 }, () => {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    return (seed / 2147483648 - 0.5) * 2e-8;
+  });
+  const out = deflatedSharpeFromReturns(quiet, 4);
+  assert.ok(out !== null && out.dsr >= 0 && out.dsr <= 1);
+});

--- a/tests-ts/deflated-sharpe.test.ts
+++ b/tests-ts/deflated-sharpe.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  deflatedSharpeFromEquity,
+  deflatedSharpeFromReturns,
+  expectedMaxSharpe,
+} from "../packages/runtime/src/deflated-sharpe.js";
+import { ExperimentConstraintsSchema } from "../packages/contracts/src/index.js";
+
+// Reference values computed with the numguard reference implementation
+// (Bailey & López de Prado 2014; same fixture returns, exact expected-max
+// formula, Acklam probit). Tolerance covers the erfc approximation (<1.2e-7).
+const RETURNS = [
+  0.01, -0.005, 0.02, 0.003, -0.01, 0.007, 0.015, -0.002, 0.004, 0.006,
+  -0.008, 0.012, 0.001, -0.003, 0.009, 0.011, -0.006, 0.002, 0.008, -0.001,
+];
+const TOL = 1e-6;
+
+test("per-period Sharpe matches reference", () => {
+  const v = deflatedSharpeFromReturns(RETURNS, 1);
+  assert.ok(v);
+  assert.ok(Math.abs(v.sharpe - 0.46684697308023854) < TOL);
+  assert.ok(Math.abs(v.skew - 0.11356875986754761) < TOL);
+  assert.ok(Math.abs(v.kurt - 2.2708234767522097) < TOL);
+});
+
+test("single trial: no deflation, DSR equals PSR", () => {
+  const v = deflatedSharpeFromReturns(RETURNS, 1);
+  assert.ok(v);
+  assert.equal(v.deflationBar, 0);
+  assert.ok(Math.abs(v.dsr - 0.978237155456722) < TOL);
+  assert.ok(Math.abs(v.dsr - v.psr) < TOL);
+});
+
+test("deflation bar rises with trial count and DSR falls", () => {
+  const v5 = deflatedSharpeFromReturns(RETURNS, 5);
+  const v50 = deflatedSharpeFromReturns(RETURNS, 50);
+  assert.ok(v5 && v50);
+  assert.ok(Math.abs(v5.deflationBar - 0.2735998280815124) < TOL);
+  assert.ok(Math.abs(v5.dsr - 0.798308301616701) < TOL);
+  assert.ok(Math.abs(v50.deflationBar - 0.5222197447964245) < TOL);
+  assert.ok(Math.abs(v50.dsr - 0.4053861113140287) < TOL);
+  assert.ok(v50.dsr < v5.dsr);
+  assert.ok(v5.dsr < v5.psr);
+});
+
+test("expected max Sharpe matches reference", () => {
+  assert.ok(Math.abs(expectedMaxSharpe(50, 0.1) - 0.2276303093889215) < TOL);
+  assert.ok(Math.abs(expectedMaxSharpe(5, 0.2) - 0.2385188003154829) < TOL);
+  assert.equal(expectedMaxSharpe(1, 0.1), 0);
+});
+
+test("equity series converts to returns and skips non-positive equity", () => {
+  const equity = [100];
+  for (const r of RETURNS) equity.push(equity[equity.length - 1] * (1 + r));
+  const fromEquity = deflatedSharpeFromEquity(equity, 5);
+  const fromReturns = deflatedSharpeFromReturns(RETURNS, 5);
+  assert.ok(fromEquity && fromReturns);
+  assert.ok(Math.abs(fromEquity.dsr - fromReturns.dsr) < TOL);
+  // a zero-equity point must not produce an infinite return
+  const withGap = [100, 0, 101, 102, 103, 104];
+  const v = deflatedSharpeFromEquity(withGap, 2);
+  assert.ok(v);
+  assert.equal(v.observationCount, 3);
+});
+
+test("insufficient or degenerate series returns null", () => {
+  assert.equal(deflatedSharpeFromReturns([0.01, 0.02], 5), null);
+  assert.equal(deflatedSharpeFromReturns([0.01, 0.01, 0.01], 5), null);
+  assert.equal(deflatedSharpeFromEquity([100, 100, 100, 100], 5), null);
+});
+
+test("constraints schema accepts and bounds deflatedSharpeGte", () => {
+  assert.ok(
+    ExperimentConstraintsSchema.safeParse({ deflatedSharpeGte: 0.95 }).success,
+  );
+  assert.ok(
+    !ExperimentConstraintsSchema.safeParse({ deflatedSharpeGte: 1.5 }).success,
+  );
+  assert.ok(
+    !ExperimentConstraintsSchema.safeParse({ deflatedSharpeGte: -0.1 }).success,
+  );
+});


### PR DESCRIPTION
## The gap

Every participant in an experiment is a trial. Users iterate strategy drafts in natural language, so N grows fast — and a gate that scores each backtest in isolation will, given enough drafts, approve the *luckiest* prompt rather than the best strategy. Under pure noise, the best of N backtests still clears any fixed bar.

## The fix

An optional `deflatedSharpeGte` constraint (0..1). It computes the deflated Sharpe ratio (Bailey & López de Prado, 2014) from each participant's backtest equity series: P(true Sharpe > expected max Sharpe of N zero-skill trials), where **N = the experiment's participant count** — a number the system already tracks. The bar rises automatically as more variants are compared, adjusting for sample length and non-normal returns.

## Implementation

- `packages/runtime/src/deflated-sharpe.ts` — pure math, no new dependencies (erfc via Numerical Recipes ~1.2e-7, Acklam probit ~1e-9). Parity-tested against the [numguard](https://github.com/ipezygj/numguard) reference implementation with hardcoded reference values (tolerance 1e-6); the same math was merged into ffn last week (pmorissette/ffn#311).
- `deflatedSharpeGte` added to `ExperimentConstraintsSchema` (strict, 0..1) and to the constraint-result key enum.
- Gate wiring in `evaluateConstraints`: PASS/FAIL against the threshold; `UNAVAILABLE` with `issueCode: EXPERIMENT_DEFLATED_SHARPE_SERIES_INSUFFICIENT` when the equity series has <3 usable returns or zero variance — fail-closed semantics preserved.
- Non-positive equity points are the non-trading-cycle sentinel (`projectArtifactEvidence` writes `0`), so transitions touching them are skipped rather than read as ±100% returns — a unit test covers this.

## Tests

`npm run check` clean; full suite `node --test dist/tests-ts/*.test.js`: **394 pass, 0 fail** (7 new tests: parity values, monotonicity in N, equity-sentinel handling, degenerate-series UNAVAILABLE, schema bounds).

Happy to adjust naming/placement to match your conventions — e.g. if you'd rather surface DSR in the scorecard (it's currently in `unavailableMetrics`) instead of or in addition to the constraint, the math module supports both.